### PR TITLE
Remove Version from Dropbox.Api.nuspec

### DIFF
--- a/dropbox-sdk-dotnet/Dropbox.Api/Dropbox.Api.nuspec
+++ b/dropbox-sdk-dotnet/Dropbox.Api/Dropbox.Api.nuspec
@@ -2,7 +2,6 @@
 <package>
   <metadata>
     <id>Dropbox.Api</id>
-    <version>5.7.0</version>
     <title>Dropbox v2 API</title>
     <authors>Dropbox</authors>
     <owners>Dropbox</owners>


### PR DESCRIPTION
We no longer need the version since our action pulls it from `github.event.release.tag_name`.

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [ ] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Does this code build successfully?
- [ ] Do all tests pass?
- [ ] Does Stylecop pass?

