### PR TITLE
Fix ReSharper's "Use string interpolation expression" and "Replace if…

### DIFF
--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxAppClient.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxAppClient.cs
@@ -62,7 +62,7 @@ namespace Dropbox.Api
                 throw new ArgumentNullException("appSecret");
             }
 
-            var rawValue = string.Format("{0}:{1}", appKey, appSecret);
+            var rawValue = $"{appKey}:{appSecret}";
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(rawValue));
         }
     }

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
@@ -430,10 +430,7 @@ namespace Dropbox.Api
             }
             finally
             {
-                if (body != null)
-                {
-                    body.Dispose();
-                }
+                body?.Dispose();
             }
         }
 


### PR DESCRIPTION
Hello,

This pull request is _very simple_ and aims to reduce the technical debt. It specifically targets the "Replace if statement with null-propagating code"  [rule](https://www.jetbrains.com/help/resharper/UseNullPropagation.html) and "Use string interpolation expression﻿" [rule](https://www.jetbrains.com/help/resharper/UseStringInterpolation.html) reported by ReSharper.


## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Does this code build successfully?
- [x] Do all tests pass?
- [x] Does Stylecop pass?

