### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/Dropbox.Api.Integration.Tests.csproj
+++ b/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/Dropbox.Api.Integration.Tests.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi@qimingyuan, I found an issue in the Dropbox.Api.Integration.Tests.csproj:

Packages MSTest.TestAdapter v2.1.1, MSTest.TestFramework v2.1.1 and Microsoft.NET.Test.Sdk v16.7.1 transitively introduce 87 dependencies into project’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/dropbox-sdk-dotnet.html)), while MSTest.TestAdapter v2.2.1, MSTest.TestFramework v2.2.1 and Microsoft.NET.Test.Sdk v16.8.0 can only introduce 55 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/dropbox-sdk-dotnet_SAT.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose