### PR TITLE
Ensure that RefreshAccessToken uses correct HttpClient

### DIFF
--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
@@ -272,7 +272,7 @@ namespace Dropbox.Api
 
             var bodyContent = new FormUrlEncodedContent(parameters);
 
-            var response = await this.defaultHttpClient.PostAsync(url, bodyContent).ConfigureAwait(false);
+            var response = await this.GetHttpClient(HostType.Api).PostAsync(url, bodyContent).ConfigureAwait(false);
 
             // if response is an invalid grant, we want to throw this exception rather than the one thrown in
             // response.EnsureSuccessStatusCode();


### PR DESCRIPTION
This fixes https://github.com/dropbox/dropbox-sdk-dotnet/issues/324 by changing RefreshAccessToken to use the provided HttpClient

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Does this code build successfully?
- [ ] Do all tests pass?
- [ ] Does Stylecop pass?

