### PR TITLE
Update documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This SDK is distributed under the MIT license, please see [LICENSE][license] for
 
 [logo]: https://cfl.dropboxstatic.com/static/images/sdk/dotnet_banner.png
 [repo]: https://github.com/dropbox/dropbox-sdk-dotnet
-[documentation]: https://dropbox.github.io/dropbox-sdk-dotnet/
+[documentation]: https://dropbox.github.io/dropbox-sdk-dotnet/gh-pages/obj/api/Dropbox.Api.html
 [examples]: https://github.com/dropbox/dropbox-sdk-dotnet/tree/main/dropbox-sdk-dotnet/Examples
 [license]: https://github.com/dropbox/dropbox-sdk-dotnet/blob/main/LICENSE
 [contributing]: https://github.com/dropbox/dropbox-sdk-dotnet/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
Change the documentation link to directly point to "API Documentation" for the SDK, instead of the readme again.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [ ] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Does this code build successfully?
- [ ] Do all tests pass?
- [ ] Does Stylecop pass?

