### PR TITLE
Fix an issue calling UploadSessionFinishAsync in SimpleTest

### DIFF
--- a/dropbox-sdk-dotnet/Examples/SimpleTest/Program.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleTest/Program.cs
@@ -500,7 +500,7 @@ namespace SimpleTest
 
                             if (idx == numChunks - 1)
                             {
-                                await client.Files.UploadSessionFinishAsync(cursor, new CommitInfo(folder + "/" + fileName), memStream);
+                                await client.Files.UploadSessionFinishAsync(cursor:cursor, commit:new CommitInfo(folder + "/" + fileName), body:memStream);
                             }
 
                             else


### PR DESCRIPTION
Add parameter names to the UploadSessionFinishAsync call in SimpleTest. The old positional parameters were out of date.