### PR TITLE
Bump actions/checkout v2→v4 and jQuery 1.10.2→3.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
         with:
@@ -38,7 +38,7 @@ jobs:
       max-parallel: 1
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
         with:
@@ -75,7 +75,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/nuget_upload.yml
+++ b/.github/workflows/nuget_upload.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Pack
         run: |
           dotnet pack \

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -8,7 +8,7 @@ jobs:
   Update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python environment
         uses: actions/setup-python@v2.2.2
         with:

--- a/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/App_Start/RouteConfig.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/App_Start/RouteConfig.cs
@@ -38,11 +38,11 @@ namespace SimpleBlogDemo
                 url: "Article/{id}",
                 defaults: new { controller = "Article", action = "Display" }
                 );
-             routes.MapRoute(
+            routes.MapRoute(
                 name: "Default",
                 url: "{controller}/{action}/{id}",
                 defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
             );
-       }
+        }
     }
 }

--- a/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Controllers/BlogsController.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Controllers/BlogsController.cs
@@ -56,7 +56,7 @@ namespace SimpleBlogDemo.Controllers
                 {
                     return View("Display", Tuple.Create(article, articles, blogname, isEditable));
                 }
-           }
+            }
         }
     }
 

--- a/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Controllers/EditController.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Controllers/EditController.cs
@@ -88,7 +88,7 @@ namespace SimpleBlogDemo.Controllers
                             var reason = uploadError.Value.Reason;
                             var id = filename.Split('.')[0];
 
-                            var message = string.Format( "Unable to update {0}. Reason: {1}", id, reason);
+                            var message = string.Format("Unable to update {0}. Reason: {1}", id, reason);
 
                             this.Flash(message, FlashLevel.Warning);
                             return RedirectToAction("Index", new { id = id });

--- a/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Controllers/HomeController.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Controllers/HomeController.cs
@@ -207,7 +207,7 @@ namespace SimpleBlogDemo.Controllers
                 this.Flash("This account has been connected to Dropbox.", FlashLevel.Success);
                 return RedirectToAction("Profile");
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 var message = string.Format(
                     "code: {0}\nAppKey: {1}\nAppSecret: {2}\nRedirectUri: {3}\nException : {4}",
@@ -234,7 +234,7 @@ namespace SimpleBlogDemo.Controllers
         }
 
         // GET: /Home/SignIn
-        public ActionResult SignIn(string returnUrl=null)
+        public ActionResult SignIn(string returnUrl = null)
         {
             if (WebSecurity.IsAuthenticated)
             {
@@ -275,7 +275,7 @@ namespace SimpleBlogDemo.Controllers
                 {
                     Response.Cookies.Get(".ASPXAUTH").Expires = DateTime.UtcNow.AddDays(30);
                 }
-           }
+            }
 
             if (!string.IsNullOrEmpty(returnUrl))
             {

--- a/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Helpers/BlogHelpers.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Helpers/BlogHelpers.cs
@@ -224,7 +224,7 @@ namespace SimpleBlogDemo.Helpers
             };
         }
     }
- 
+
     public class Article
     {
         public Article(string name, ArticleMetadata metadata, HtmlString content)

--- a/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Helpers/FlashHelpers.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Helpers/FlashHelpers.cs
@@ -30,7 +30,8 @@ namespace SimpleBlogDemo.Helpers
 
             flashStack = flashStackObject as List<FlashItem>;
 
-            flashStack.Add(new FlashItem {
+            flashStack.Add(new FlashItem
+            {
                 Message = message,
                 Level = level
             });
@@ -58,7 +59,7 @@ namespace SimpleBlogDemo.Helpers
 
             var level = top.Level.ToString().ToLowerInvariant();
             var message = HttpUtility.HtmlEncode(top.Message).Replace("\r", "").Replace("\n", "<br />\n").Replace("'", "@squo;");
-            
+
             var builder = new StringBuilder();
             builder.AppendFormat("<div class=\"margin-top-10 alert alert-{0}\">", level).AppendLine();
             builder.AppendLine("  <span class=\"close\" data-dismiss=\"alert\">&times;</span>");

--- a/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Helpers/MaybeRequireHttps.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/Helpers/MaybeRequireHttps.cs
@@ -4,37 +4,37 @@ namespace SimpleBlogDemo.Helpers
     using System.Web.Configuration;
     using System.Web.Mvc;
 
-	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true,
-		AllowMultiple = false)]
-	public class RequireHttpsOrXForwardedAttribute : RequireHttpsAttribute
-	{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true,
+        AllowMultiple = false)]
+    public class RequireHttpsOrXForwardedAttribute : RequireHttpsAttribute
+    {
         private string Environment = WebConfigurationManager.AppSettings["Environment"];
-         
-		public override void OnAuthorization(AuthorizationContext filterContext)
-		{
-			if (filterContext == null)
-			{
-				throw new ArgumentNullException("filterContext");
-			}
 
-			if (filterContext.HttpContext.Request.IsSecureConnection)
-			{
-				return;
-			}
- 
-			if (string.Equals(filterContext.HttpContext.Request.Headers["X-Forwarded-Proto"],
-				"https",
-				StringComparison.InvariantCultureIgnoreCase))
-			{
-				return;
-			}
- 
-			if (filterContext.HttpContext.Request.IsLocal)
-			{
-				return;
-			}
- 
-			HandleNonHttpsRequest(filterContext);
-		}
-	}
+        public override void OnAuthorization(AuthorizationContext filterContext)
+        {
+            if (filterContext == null)
+            {
+                throw new ArgumentNullException("filterContext");
+            }
+
+            if (filterContext.HttpContext.Request.IsSecureConnection)
+            {
+                return;
+            }
+
+            if (string.Equals(filterContext.HttpContext.Request.Headers["X-Forwarded-Proto"],
+                "https",
+                StringComparison.InvariantCultureIgnoreCase))
+            {
+                return;
+            }
+
+            if (filterContext.HttpContext.Request.IsLocal)
+            {
+                return;
+            }
+
+            HandleNonHttpsRequest(filterContext);
+        }
+    }
 }

--- a/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/packages.config
+++ b/dropbox-sdk-dotnet/Examples/SimpleBlogDemo/packages.config
@@ -5,7 +5,7 @@
   <package id="CSharpVerbalExpressions" version="0.1" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="HtmlTags" version="2.0.0.181" targetFramework="net45" />
-  <package id="jQuery" version="1.10.2" targetFramework="net45" />
+  <package id="jQuery" version="3.5.0" targetFramework="net45" />
   <package id="jQuery.Validation" version="1.19.4" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />

--- a/dropbox-sdk-dotnet/Examples/SimpleBusinessDashboard/App_Start/RouteConfig.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleBusinessDashboard/App_Start/RouteConfig.cs
@@ -13,11 +13,11 @@ namespace SimpleBusinessDashboard
         {
             routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
 
-             routes.MapRoute(
+            routes.MapRoute(
                 name: "Default",
                 url: "{controller}/{action}/{id}",
                 defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
             );
-       }
+        }
     }
 }

--- a/dropbox-sdk-dotnet/Examples/SimpleBusinessDashboard/Controllers/HomeController.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleBusinessDashboard/Controllers/HomeController.cs
@@ -211,7 +211,7 @@ namespace SimpleBusinessDashboard.Controllers
                 this.Flash("This account has been connected to Dropbox.", FlashLevel.Success);
                 return RedirectToAction("Index");
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 var message = string.Format(
                     "code: {0}\nAppKey: {1}\nAppSecret: {2}\nRedirectUri: {3}\nException : {4}",

--- a/dropbox-sdk-dotnet/Examples/SimpleBusinessDashboard/Helpers/FlashHelpers.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleBusinessDashboard/Helpers/FlashHelpers.cs
@@ -30,7 +30,8 @@ namespace SimpleBusinessDashboard.Helpers
 
             flashStack = flashStackObject as List<FlashItem>;
 
-            flashStack.Add(new FlashItem {
+            flashStack.Add(new FlashItem
+            {
                 Message = message,
                 Level = level
             });
@@ -58,7 +59,7 @@ namespace SimpleBusinessDashboard.Helpers
 
             var level = top.Level.ToString().ToLowerInvariant();
             var message = HttpUtility.HtmlEncode(top.Message).Replace("\r", "").Replace("\n", "<br />\n").Replace("'", "@squo;");
-            
+
             var builder = new StringBuilder();
             builder.AppendFormat("<div class=\"custom-alert alert alert-{0}\">", level).AppendLine();
             builder.AppendLine("  <span class=\"close\" data-dismiss=\"alert\">&times;</span>");

--- a/dropbox-sdk-dotnet/Examples/SimpleBusinessDashboard/packages.config
+++ b/dropbox-sdk-dotnet/Examples/SimpleBusinessDashboard/packages.config
@@ -5,7 +5,7 @@
   <package id="CSharpVerbalExpressions" version="0.1" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="HtmlTags" version="2.0.0.181" targetFramework="net45" />
-  <package id="jQuery" version="1.10.2" targetFramework="net45" />
+  <package id="jQuery" version="3.5.0" targetFramework="net45" />
   <package id="jQuery.Validation" version="1.19.4" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />

--- a/dropbox-sdk-dotnet/Examples/UniversalDemo/UniversalDemo/UniversalDemo.Shared/App.xaml.cs
+++ b/dropbox-sdk-dotnet/Examples/UniversalDemo/UniversalDemo/UniversalDemo.Shared/App.xaml.cs
@@ -236,7 +236,7 @@ namespace UniversalDemo
 #endif
             base.OnWindowCreated(args);
         }
- 
+
         /// <summary>
         /// Sets the new dropbox client.
         /// </summary>
@@ -273,5 +273,5 @@ namespace UniversalDemo
             // TODO: Save application state and stop any background activity
             deferral.Complete();
         }
-   }
+    }
 }

--- a/dropbox-sdk-dotnet/Examples/UniversalDemo/UniversalDemo/UniversalDemo.Shared/SwipeManager.cs
+++ b/dropbox-sdk-dotnet/Examples/UniversalDemo/UniversalDemo/UniversalDemo.Shared/SwipeManager.cs
@@ -24,7 +24,6 @@ namespace UniversalDemo
             this.Root = root;
             this.ImageSet = imageSet;
 
-           
             this.Root.ManipulationMode = ManipulationModes.TranslateX;
             this.Root.ManipulationDelta += this.OnManipulationDelta;
             this.Root.ManipulationCompleted += this.OnManipulationCompleted;

--- a/dropbox-sdk-dotnet/Examples/UniversalDemo/UniversalDemo/UniversalDemo.Shared/ViewModel/AppImageSet.cs
+++ b/dropbox-sdk-dotnet/Examples/UniversalDemo/UniversalDemo/UniversalDemo.Shared/ViewModel/AppImageSet.cs
@@ -204,5 +204,5 @@ namespace UniversalDemo.ViewModel
             });
         }
 
-     }
+    }
 }


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v2 to v4 across all workflows (`ci.yml`, `nuget_upload.yml`, `spec_update.yml`) to resolve Node.js 16/20 deprecation warnings in GitHub Actions.
- Upgrade jQuery from 1.10.2 to 3.5.0 in `SimpleBlogDemo` and `SimpleBusinessDashboard` example projects to address known XSS vulnerabilities (CVE-2020-11022, CVE-2020-11023).

## Supersedes

- #363 (actions/checkout 2→4, had merge conflicts)
- #354 (jQuery bump SimpleBlogDemo, had merge conflicts)
- #353 (jQuery bump SimpleBusinessDashboard, had merge conflicts)

#356 can also be closed — it bumps codecov from v1.3.2→v3.1.4, but `main` already uses `@v4`.

## Test plan

- [x] CI passes (unit tests, integration tests, linter) — the checkout action change is backward-compatible
- [x] jQuery bump only affects example project `packages.config` metadata; no runtime code changes