### PR TITLE
Use caller-supplied HttpClient for token refresh (#324)

### DIFF
--- a/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/DropboxApiTests.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/DropboxApiTests.cs
@@ -174,6 +174,42 @@ namespace Dropbox.Api.Tests
         }
 
         /// <summary>
+        /// Tests that the token refresh uses the caller-supplied HttpClient.
+        /// </summary>
+        /// <returns>The <see cref="Task" />.</returns>
+        [TestMethod]
+        public async Task TestRefreshUsesSuppliedHttpClient()
+        {
+            var refreshRequests = 0;
+            var mockHandler = new MockHttpMessageHandler((r, s) =>
+            {
+                if (r.RequestUri.AbsoluteUri.Contains("oauth2/token"))
+                {
+                    refreshRequests++;
+                }
+
+                return s(r);
+            });
+
+            var mockClient = new HttpClient(mockHandler);
+            var config = new DropboxClientConfig { HttpClient = mockClient };
+
+            // Past expiry forces a refresh; SDK compares against DateTime.Now.
+            var client = new DropboxClient(
+                "expired-access-token",
+                userRefreshToken,
+                DateTime.Now.AddMinutes(-5),
+                appKey,
+                appSecret,
+                config);
+
+            var result = await client.Users.GetCurrentAccountAsync();
+
+            Assert.IsNotNull(result.Email);
+            Assert.AreEqual(1, refreshRequests, "The refresh request should flow through the supplied HttpClient.");
+        }
+
+        /// <summary>
         /// Test get metadata.
         /// </summary>
         /// <returns>The <see cref="Task"/>.</returns>

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
@@ -272,7 +272,8 @@ namespace Dropbox.Api
 
             var bodyContent = new FormUrlEncodedContent(parameters);
 
-            var response = await this.defaultHttpClient.PostAsync(url, bodyContent).ConfigureAwait(false);
+            // Honor a caller-supplied HttpClient here too.
+            var response = await this.GetHttpClient(HostType.Api).PostAsync(url, bodyContent).ConfigureAwait(false);
 
             // if response is an invalid grant, we want to throw this exception rather than the one thrown in
             // response.EnsureSuccessStatusCode();


### PR DESCRIPTION
Fixes #324.

RefreshAccessToken sent the OAuth token request through the SDK's internal default HttpClient, ignoring a caller-supplied client. In high-traffic apps this leaked connections and exhausted ports.

- Route the refresh through GetHttpClient(HostType.Api), same as normal requests.
- Add a regression test asserting the refresh flows through the supplied HttpClient (verified it fails when the fix is reverted).