### PR TITLE
Fix OAuthPKCE example browser launch on .NET Core (#334)

### DIFF
--- a/dropbox-sdk-dotnet/Examples/OAuthPKCE/Program.cs
+++ b/dropbox-sdk-dotnet/Examples/OAuthPKCE/Program.cs
@@ -185,7 +185,10 @@ namespace OauthPKCE
 
                     http.Start();
 
-                    System.Diagnostics.Process.Start(authorizeUri.ToString());
+                    // UseShellExecute must be true to open a URL with the default
+                    // browser; on .NET Core the default is false, which throws
+                    // "The system cannot find the file specified" (issue #334).
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(authorizeUri.ToString()) { UseShellExecute = true });
 
                     // Handle OAuth redirect and send URL fragment to local server using JS.
                     await HandleOAuth2Redirect(http);


### PR DESCRIPTION
Fixes #334.

Process.Start(url) throws on .NET Core because UseShellExecute defaults to false. Pass a ProcessStartInfo with UseShellExecute = true so the URL opens in the default browser.