### PR TITLE
Return state from ProcessCodeFlowAsync (#248)

### DIFF
--- a/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/DropboxApiTests.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/DropboxApiTests.cs
@@ -174,6 +174,30 @@ namespace Dropbox.Api.Tests
         }
 
         /// <summary>
+        /// Tests that ProcessCodeFlowAsync returns the state passed to it.
+        /// </summary>
+        /// <returns>The <see cref="Task" />.</returns>
+        [TestMethod]
+        public async Task TestProcessCodeFlowReturnsState()
+        {
+            const string state = "my-state-value";
+            var tokenJson = "{\"access_token\":\"token\",\"token_type\":\"bearer\",\"uid\":\"123\"}";
+
+            var mockHandler = new MockHttpMessageHandler((r, s) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(tokenJson, Encoding.UTF8, "application/json"),
+                }));
+            var mockClient = new HttpClient(mockHandler);
+
+            var responseUri = new Uri("https://localhost/token?code=the-code&state=" + state);
+            var response = await DropboxOAuth2Helper.ProcessCodeFlowAsync(
+                responseUri, "appKey", "appSecret", null, state, mockClient);
+
+            Assert.AreEqual(state, response.State);
+        }
+
+        /// <summary>
         /// Tests that the token refresh uses the caller-supplied HttpClient.
         /// </summary>
         /// <returns>The <see cref="Task" />.</returns>

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxOauth2Helper.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxOauth2Helper.cs
@@ -497,8 +497,9 @@ namespace Dropbox.Api
         /// again.</param>
         /// <param name="client">An optional http client instance used to make requests.</param>
         /// <param name="codeVerifier">The code verifier for PKCE flow.  If using PKCE, please us the PKCEOauthFlow object.</param>
+        /// <param name="state">The state to return on the response, if any.</param>
         /// <returns>The authorization response, containing the access token and uid of the authorized user.</returns>
-        public static async Task<OAuth2Response> ProcessCodeFlowAsync(string code, string appKey, string appSecret = null, string redirectUri = null, HttpClient client = null, string codeVerifier = null)
+        public static async Task<OAuth2Response> ProcessCodeFlowAsync(string code, string appKey, string appSecret = null, string redirectUri = null, HttpClient client = null, string codeVerifier = null, string state = null)
         {
             if (string.IsNullOrEmpty(code))
             {
@@ -573,7 +574,7 @@ namespace Dropbox.Api
                     return new OAuth2Response(
                         json["access_token"].ToString(),
                         json["uid"].ToString(),
-                        null,
+                        state,
                         json["token_type"].ToString());
                 }
 
@@ -581,7 +582,7 @@ namespace Dropbox.Api
                     json["access_token"].ToString(),
                     refreshToken,
                     json["uid"].ToString(),
-                    null,
+                    state,
                     json["token_type"].ToString(),
                     expiresIn,
                     scopeList);
@@ -665,7 +666,7 @@ namespace Dropbox.Api
                 throw new ArgumentException("The responseUri is missing a code value in the query component.", "responseUri");
             }
 
-            return ProcessCodeFlowAsync(code, appKey, appSecret, redirectUri, client, codeVerifier);
+            return ProcessCodeFlowAsync(code, appKey, appSecret, redirectUri, client, codeVerifier, state);
         }
     }
 


### PR DESCRIPTION
Fixes #248.

The Uri overload of ProcessCodeFlowAsync validated the state parameter but never returned it, so OAuth2Response.State was always null. Thread state through to the inner overload and into the response.

Added a test that reproduces the null state and passes with the fix.