### PR TITLE
Add DisposeUploadStream option to keep upload stream open (#340)

### DIFF
--- a/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/DropboxApiTests.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/DropboxApiTests.cs
@@ -210,6 +210,36 @@ namespace Dropbox.Api.Tests
         }
 
         /// <summary>
+        /// Tests that upload disposes the stream by default.
+        /// </summary>
+        /// <returns>The <see cref="Task" />.</returns>
+        [TestMethod]
+        public async Task TestUploadDisposesStreamByDefault()
+        {
+            var stream = GetStream("abc");
+            await client.Files.UploadAsync(testingPath + "/Foo.txt", body: stream);
+
+            Assert.ThrowsException<ObjectDisposedException>(() => stream.Position);
+        }
+
+        /// <summary>
+        /// Tests that upload keeps the stream open when DisposeUploadStream is false.
+        /// </summary>
+        /// <returns>The <see cref="Task" />.</returns>
+        [TestMethod]
+        public async Task TestUploadKeepsStreamOpenWhenConfigured()
+        {
+            var config = new DropboxClientConfig { DisposeUploadStream = false };
+            var keepOpenClient = new DropboxClient(userAccessToken, config);
+
+            var stream = GetStream("abc");
+            await keepOpenClient.Files.UploadAsync(testingPath + "/Bar.txt", body: stream);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            Assert.AreEqual(3, stream.Length);
+        }
+
+        /// <summary>
         /// Test get metadata.
         /// </summary>
         /// <returns>The <see cref="Task"/>.</returns>

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxClientConfig.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxClientConfig.cs
@@ -66,5 +66,12 @@ namespace Dropbox.Api
         /// http client with a longer timeout (480 seconds) will be created.
         /// </summary>
         public HttpClient LongPollHttpClient { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether an upload stream is disposed by
+        /// the SDK after the request completes. Default is <c>true</c> for
+        /// backwards compatibility; set to <c>false</c> to keep the stream open.
+        /// </summary>
+        public bool DisposeUploadStream { get; set; } = true;
     }
 }

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
@@ -431,7 +431,10 @@ namespace Dropbox.Api
             }
             finally
             {
-                body?.Dispose();
+                if (this.options.DisposeUploadStream)
+                {
+                    body?.Dispose();
+                }
             }
         }
 
@@ -934,7 +937,8 @@ namespace Dropbox.Api
             DefaultApiContentDomain,
             DefaultApiNotifyDomain,
             config.HttpClient,
-            config.LongPollHttpClient)
+            config.LongPollHttpClient,
+            config.DisposeUploadStream)
         {
         }
 
@@ -958,6 +962,7 @@ namespace Dropbox.Api
         /// http client will be created.</param>
         /// <param name="longPollHttpClient">The custom http client for long poll. If not provided, a default
         /// http client with longer timeout will be created.</param>
+        /// <param name="disposeUploadStream">Whether to dispose the upload stream after the request.</param>
         public DropboxRequestHandlerOptions(
             string oauth2AccessToken,
             string oauth2RefreshToken,
@@ -970,7 +975,8 @@ namespace Dropbox.Api
             string apiContentHostname,
             string apiNotifyHostname,
             HttpClient httpClient,
-            HttpClient longPollHttpClient)
+            HttpClient longPollHttpClient,
+            bool disposeUploadStream = true)
         {
             var type = typeof(DropboxRequestHandlerOptions);
 #if PORTABLE40
@@ -987,6 +993,7 @@ namespace Dropbox.Api
 
             this.HttpClient = httpClient;
             this.LongPollHttpClient = longPollHttpClient;
+            this.DisposeUploadStream = disposeUploadStream;
             this.OAuth2AccessToken = oauth2AccessToken;
             this.OAuth2RefreshToken = oauth2RefreshToken;
             this.OAuth2AccessTokenExpiresAt = oauth2AccessTokenExpiresAt;
@@ -1040,6 +1047,11 @@ namespace Dropbox.Api
         /// Gets the HTTP client use to send long poll requests to the server.
         /// </summary>
         public HttpClient LongPollHttpClient { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether to dispose the upload stream after the request.
+        /// </summary>
+        public bool DisposeUploadStream { get; private set; }
 
         /// <summary>
         /// Gets the user agent string.


### PR DESCRIPTION
Fixes #340.

UploadAsync always disposed the caller's stream as a hidden side effect. Added DropboxClientConfig.DisposeUploadStream (default true, so existing behavior is unchanged); set it to false to keep the stream open after upload.

Non-breaking: only touches hand-written files, no interface or generated-code changes.

Tests: one asserts the default still disposes, one asserts the stream stays open when the option is false (reproduced the ObjectDisposedException before the fix).