### PR TITLE
Serialize integration test runs to avoid rate limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
           fail_ci_if_error: true
           directory: dropbox-sdk-dotnet/Dropbox.Api.Unit.Tests/TestResults/
   IntegrationTests:
+    concurrency:
+      group: integration-tests
+      cancel-in-progress: false
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,9 @@ jobs:
           directory: dropbox-sdk-dotnet/Dropbox.Api.Unit.Tests/TestResults/
   IntegrationTests:
     concurrency:
-      group: integration-tests
+      group: ${{ github.workflow }}-integration-tests
       cancel-in-progress: false
+      queue: max
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]


### PR DESCRIPTION
Concurrent CI runs (multiple open PRs building at once) share a single Dropbox account and trip API rate limits, causing flaky RateLimitException failures.

Add a concurrency group to the IntegrationTests job so only one run executes at a time across all PRs/branches. cancel-in-progress: false queues runs rather than cancelling them.