### PR TITLE
Throw AuthException for revoked or invalid refresh token (#232)

### DIFF
--- a/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/DropboxApiTests.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/DropboxApiTests.cs
@@ -174,6 +174,28 @@ namespace Dropbox.Api.Tests
         }
 
         /// <summary>
+        /// Tests that a revoked or invalid refresh token surfaces as an AuthException.
+        /// </summary>
+        /// <returns>The <see cref="Task" />.</returns>
+        [TestMethod]
+        public async Task TestRevokedRefreshTokenThrowsAuthException()
+        {
+            var badClient = new DropboxClient("invalid-or-revoked-refresh-token", appKey, appSecret);
+
+            var ex = await Assert.ThrowsExceptionAsync<AuthException>(
+                () => badClient.Users.GetCurrentAccountAsync());
+
+            // The message should carry the OAuth error detail, not raw JSON.
+            Assert.IsFalse(string.IsNullOrEmpty(ex.Message));
+            Assert.IsFalse(ex.Message.TrimStart().StartsWith("{"), "Message should not be raw JSON.");
+
+            // The status code should reflect the actual response (400 for invalid_grant).
+#pragma warning disable CS0618
+            Assert.AreEqual(400, ex.StatusCode);
+#pragma warning restore CS0618
+        }
+
+        /// <summary>
         /// Tests that ProcessCodeFlowAsync returns the state passed to it.
         /// </summary>
         /// <returns>The <see cref="Task" />.</returns>

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxException.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxException.cs
@@ -120,6 +120,19 @@ namespace Dropbox.Api
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="AuthException"/> class.
+        /// </summary>
+        /// <param name="requestId">The Dropbox request ID.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="statusCode">The HTTP status code that prompted this exception.</param>
+        internal AuthException(string requestId, string message, int statusCode)
+            : base(requestId, message)
+        {
+            this.StatusCode = statusCode;
+            this.RequestUri = null;
+        }
+
+        /// <summary>
         /// Gets the HTTP status code that prompted this exception.
         /// </summary>
         /// <value>

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
@@ -275,14 +275,14 @@ namespace Dropbox.Api
             // Honor a caller-supplied HttpClient here too.
             var response = await this.GetHttpClient(HostType.Api).PostAsync(url, bodyContent).ConfigureAwait(false);
 
-            // if response is an invalid grant, we want to throw this exception rather than the one thrown in
-            // response.EnsureSuccessStatusCode();
-            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            // A revoked or invalid refresh token returns invalid_grant (as 400 or
+            // 401); surface it as an AuthException instead of a generic error.
+            if (!response.IsSuccessStatusCode)
             {
                 var reason = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                if (reason == "invalid_grant")
+                if (this.TryParseOAuthError(reason, out var error, out var description) && error == "invalid_grant")
                 {
-                    throw AuthException.Decode(reason, () => new AuthException(this.GetRequestId(response)));
+                    throw new AuthException(this.GetRequestId(response), description ?? error, (int)response.StatusCode);
                 }
             }
 
@@ -653,6 +653,33 @@ namespace Dropbox.Api
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Parses an OAuth token endpoint error body of the form
+        /// <c>{ "error": "...", "error_description": "..." }</c>.
+        /// </summary>
+        /// <param name="body">The response body.</param>
+        /// <param name="error">The parsed error code, if any.</param>
+        /// <param name="description">The parsed error description, if any.</param>
+        /// <returns><c>true</c> if an error code was found.</returns>
+        private bool TryParseOAuthError(string body, out string error, out string description)
+        {
+            error = null;
+            description = null;
+
+            try
+            {
+                var json = JObject.Parse(body);
+                error = (string)json["error"];
+                description = (string)json["error_description"];
+            }
+            catch (Newtonsoft.Json.JsonException)
+            {
+                return false;
+            }
+
+            return error != null;
         }
 
         /// <summary>

--- a/dropbox-sdk-dotnet/Dropbox.Api/StructuredException.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/StructuredException.cs
@@ -29,6 +29,17 @@ namespace Dropbox.Api
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="StructuredException{TError}"/> class.
+        /// </summary>
+        /// <param name="requestId">The Dropbox request id.</param>
+        /// <param name="message">The error message.</param>
+        protected internal StructuredException(string requestId, string message)
+            : base(requestId, message)
+        {
+            this.ErrorMessage = message;
+        }
+
+        /// <summary>
         /// Gets the error response.
         /// </summary>
         /// <value>


### PR DESCRIPTION
Fixes #232.

RefreshAccessToken only mapped invalid_grant to an AuthException on a 401 with an exact-string body. A revoked or invalid refresh token actually returns 400 with a JSON invalid_grant body, so it surfaced as a generic HttpRequestException with no useful detail.

- Detect invalid_grant by parsing the OAuth error JSON on any non-success status (400 or 401).
- Throw AuthException carrying the error_description and the real HTTP status code.
- Add AuthException/StructuredException constructors that accept a message and status code.
- Add a live test asserting the exception type, a non-JSON message, and StatusCode 400.

Verified against the live token endpoint (reproduced the generic exception before the fix).