### PR TITLE
Fix README: cert-migration note, verify example, and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Important: Make sure you're using v7.0.0 or newer of this SDK by January 2026 for continued compatibility with the Dropbox API servers. Please refer to this blog post for more information: https://dropbox.tech/developers/api-server-certificate-changes
+## Important: Use v7.0.0 or newer of this SDK for compatibility with the Dropbox API servers. Older versions stopped working in January 2026. Please refer to this blog post for more information: https://dropbox.tech/developers/api-server-certificate-changes
 
 [![Logo][logo]][repo]
 
@@ -6,7 +6,7 @@
 [![NuGet](https://img.shields.io/nuget/v/Dropbox.Api.svg)](https://www.nuget.org/packages/Dropbox.Api)
 [![codecov](https://codecov.io/gh/dropbox/dropbox-sdk-dotnet/branch/main/graph/badge.svg)](https://codecov.io/gh/dropbox/dropbox-sdk-dotnet)
 
-The offical Dropbox SDK for DotNet.
+The official Dropbox SDK for DotNet.
 
 Documentation can be found on [GitHub Pages][documentation]
 
@@ -41,20 +41,25 @@ We provide [Examples][examples] to help get you started with a lot of the basic 
 
 For file upload calls whose request type includes `ContentHash`, the SDK automatically computes and sends a Dropbox `content_hash` when the upload stream is seekable. The server rejects the upload if the hash does not match the bytes it receives.
 
-Because `content_hash` is part of the request header, this default-on validation reads the stream once to compute the hash, seeks back to the original position, and then reads it again for the upload body. That is 2x read I/O for seekable uploads. For local files the second read is often served from OS cache; for slow, network-backed, or encrypted streams it can materially increase upload time. Non-seekable streams are uploaded without automatic hashing. A manually supplied `contentHash` argument always wins. If a seekable stream has unusual read or rewind behavior, disable automatic hashing for that upload or client.
+Because `content_hash` is part of the request header, this default-on validation reads the stream once to compute the hash, seeks back to the original position, and then reads it again for the upload body. That is two reads (2×) of I/O for seekable uploads. For local files the second read is often served from OS cache; for slow, network-backed, or encrypted streams it can materially increase upload time. Non-seekable streams are uploaded without automatic hashing. A manually supplied `contentHash` argument always wins. If a seekable stream has unusual read or rewind behavior, disable automatic hashing for that upload or client.
 
-To compute a Dropbox content hash manually:
+You can also compute a content hash yourself, for example to verify a downloaded file against its `ContentHash` metadata:
 
 ```csharp
+using Dropbox.Api.Files;
+
 using (var stream = File.OpenRead("local-file.txt"))
 {
     var contentHash = ContentHasher.ComputeHash(stream);
+    // Compare against metadata.ContentHash returned by the server.
 }
 ```
 
 To disable automatic hashing for one upload, wrap the stream:
 
 ```csharp
+using Dropbox.Api.Files;
+
 await client.Files.UploadAsync(
     new UploadArg("/remote-file.txt"),
     ContentHasher.WithoutAutoContentHash(stream));


### PR DESCRIPTION
Docs-only cleanup ahead of the next release.

- Reword the v7.0.0 requirement to past tense now that the January 2026 certificate-migration deadline has passed.
- Show the ContentHasher example verifying a downloaded file against its ContentHash metadata (addresses #34) and add the required using directive.
- Fix the 'offical' -> 'official' typo.