### PR TITLE
Fetch GitHub Actions secrets from AWS Secrets Manager via OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    permissions:  # required for OIDC authentication (coverage upload token)
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET 8
@@ -23,15 +26,36 @@ jobs:
         # We don't have a good cross-platform way of splitting long lines
         run: |
           dotnet test dropbox-sdk-dotnet/Dropbox.Api.Unit.Tests --collect:"XPlat Code Coverage" -- 'DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile=**/Generated/**/*.cs'
+      # Coverage upload needs the Codecov token from AWS Secrets Manager, which
+      # requires OIDC. Fork PRs cannot assume the role (GitHub withholds
+      # id-token from fork runs), so the coverage-upload steps are gated to
+      # same-repo runs; unit tests themselves still run everywhere.
+      - name: Configure AWS credentials (OIDC)
+        if: matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-dotnet-repo
+          aws-region: us-west-2
+      - name: Get Codecov token from AWS Secrets Manager
+        if: matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            CODECOV_TOKEN,codecov-token-dropbox-sdk-dotnet
+          parse-json-secrets: false
       - name: Publish Coverage
         uses: codecov/codecov-action@v4
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           flags: unit
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: true
           directory: dropbox-sdk-dotnet/Dropbox.Api.Unit.Tests/TestResults/
   IntegrationTests:
+    # Integration tests require Dropbox app credentials fetched from AWS Secrets
+    # Manager via OIDC. Fork PRs cannot assume the role, so skip the job on fork
+    # PRs (it still runs on same-repo PRs, push to main, and the nightly cron).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     concurrency:
       group: ${{ github.workflow }}-integration-tests
       cancel-in-progress: false
@@ -41,28 +65,47 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
       max-parallel: 1
     runs-on: ${{ matrix.os }}
+    permissions:  # required for OIDC authentication
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.x'
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-dotnet-repo
+          aws-region: us-west-2
+      # The integration credentials are stored as a single JSON secret; with
+      # parse-json-secrets each JSON key is exposed as env var CREDS_<KEY>
+      # (e.g. CREDS_LEGACY_APP_KEY). The Codecov token is a plain-string secret
+      # in the same fetch.
+      - name: Get integration credentials from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            CREDS,dotnet-integration-test-creds
+            CODECOV_TOKEN,codecov-token-dropbox-sdk-dotnet
+          parse-json-secrets: true
       - name: Test Legacy User
         env:
-          DROPBOX_INTEGRATION_appKey: ${{ secrets.LEGACY_APP_KEY }}
-          DROPBOX_INTEGRATION_appSecret: ${{ secrets.LEGACY_APP_SECRET }}
-          DROPBOX_INTEGRATION_userAccessToken: ${{ secrets.LEGACY_APP_ACCESS_TOKEN }}
-          DROPBOX_INTEGRATION_userRefreshToken: ${{ secrets.LEGACY_APP_REFRESH_TOKEN }}
-          DROPBOX_INTEGRATION_teamAccessToken: ${{ secrets.TEAM_APP_ACCESS_TOKEN }}
+          DROPBOX_INTEGRATION_appKey: ${{ env.CREDS_LEGACY_APP_KEY }}
+          DROPBOX_INTEGRATION_appSecret: ${{ env.CREDS_LEGACY_APP_SECRET }}
+          DROPBOX_INTEGRATION_userAccessToken: ${{ env.CREDS_LEGACY_APP_ACCESS_TOKEN }}
+          DROPBOX_INTEGRATION_userRefreshToken: ${{ env.CREDS_LEGACY_APP_REFRESH_TOKEN }}
+          DROPBOX_INTEGRATION_teamAccessToken: ${{ env.CREDS_TEAM_APP_ACCESS_TOKEN }}
         run: |
           dotnet test dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests --collect:"XPlat Code Coverage" -- 'DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile=**/Generated/**/*.cs'
       - name: Test Scoped User
         env:
-          DROPBOX_INTEGRATION_appKey: ${{ secrets.SCOPED_APP_KEY }}
-          DROPBOX_INTEGRATION_appSecret: ${{ secrets.SCOPED_APP_SECRET }}
-          DROPBOX_INTEGRATION_userAccessToken: ${{ secrets.SCOPED_APP_ACCESS_TOKEN }}
-          DROPBOX_INTEGRATION_userRefreshToken: ${{ secrets.SCOPED_APP_REFRESH_TOKEN }}
-          DROPBOX_INTEGRATION_teamAccessToken: ${{ secrets.TEAM_APP_ACCESS_TOKEN }}
+          DROPBOX_INTEGRATION_appKey: ${{ env.CREDS_SCOPED_APP_KEY }}
+          DROPBOX_INTEGRATION_appSecret: ${{ env.CREDS_SCOPED_APP_SECRET }}
+          DROPBOX_INTEGRATION_userAccessToken: ${{ env.CREDS_SCOPED_APP_ACCESS_TOKEN }}
+          DROPBOX_INTEGRATION_userRefreshToken: ${{ env.CREDS_SCOPED_APP_REFRESH_TOKEN }}
+          DROPBOX_INTEGRATION_teamAccessToken: ${{ env.CREDS_TEAM_APP_ACCESS_TOKEN }}
         run: |
           dotnet test dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests --collect:"XPlat Code Coverage" -- 'DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile=**/Generated/**/*.cs'
       - name: Publish Coverage
@@ -70,7 +113,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         with:
           flags: integration
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: true
           directory: dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/TestResults/
   Linter:

--- a/.github/workflows/nuget_upload.yml
+++ b/.github/workflows/nuget_upload.yml
@@ -8,8 +8,26 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:  # required for OIDC authentication
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
+      # The IAM role and Secrets Manager secret are provisioned for this repo in
+      # rSERVER: configs/aws/secrets/account_configs/aws_dropbox_stone/secrets_config.py
+      # The role is repository-wide so the release-triggered publish (a tag ref)
+      # can assume it.
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-dotnet-repo
+          aws-region: us-west-2
+      - name: Get NuGet token from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            NUGET_TOKEN,nuget-api-token-dropbox-sdk-dotnet
+          parse-json-secrets: false
       - name: Pack
         run: |
           dotnet pack \
@@ -23,4 +41,4 @@ jobs:
           dotnet nuget push \
           dropbox-sdk-dotnet/Dropbox.Api/bin/Release/Dropbox.Api.$(echo "${{ github.event.release.tag_name }}" | cut -c 2-).nupkg \
           --source https://api.nuget.org/v3/index.json \
-          --api-key ${{ secrets.NUGET_TOKEN }}
+          --api-key ${{ env.NUGET_TOKEN }}

--- a/.github/workflows/nuget_upload.yml
+++ b/.github/workflows/nuget_upload.yml
@@ -13,10 +13,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      # The IAM role and Secrets Manager secret are provisioned for this repo in
-      # rSERVER: configs/aws/secrets/account_configs/aws_dropbox_stone/secrets_config.py
-      # The role is repository-wide so the release-triggered publish (a tag ref)
-      # can assume it.
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -7,8 +7,22 @@ on:
 jobs:
   Update:
     runs-on: ubuntu-latest
+    permissions:  # required for OIDC authentication
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-dotnet-repo
+          aws-region: us-west-2
+      - name: Get spec-update token from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            SPEC_UPDATE_TOKEN,spec-update-token-dropbox-sdk-dotnet
+          parse-json-secrets: false
       - name: Setup Python environment
         uses: actions/setup-python@v6.3.0
         with:
@@ -57,7 +71,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8.1.1
         if: steps.git-diff-num.outputs.num-diff != 0
         with:
-          token: ${{ secrets.SPEC_UPDATE_TOKEN }}
+          token: ${{ env.SPEC_UPDATE_TOKEN }}
           commit-message: |
             ${{ steps.git-diff.outputs.commit}}
           branch: ${{ steps.git-branch.outputs.branch }}


### PR DESCRIPTION
## Summary

Moves the GitHub Actions secrets these workflows use out of GitHub repo secrets and into AWS Secrets Manager, fetched at runtime via GitHub OIDC — the same approach `dropbox/stone` and `dropbox-sdk-python` now use. The old GitHub secrets are being retired.

## Changes

All three workflows assume the repo's OIDC role (`oidc-github-dropbox-dropbox-sdk-dotnet-repo`, AWS account `082972943155`, `us-west-2`) and fetch their secrets with `aws-actions/aws-secretsmanager-get-secrets`:

- **`nuget_upload.yml`** — `NUGET_TOKEN` from `nuget-api-token-dropbox-sdk-dotnet`.
- **`spec_update.yml`** — `SPEC_UPDATE_TOKEN` from `spec-update-token-dropbox-sdk-dotnet`.
- **`ci.yml`**
  - `IntegrationTests`: the Dropbox app credentials from a single JSON secret `dotnet-integration-test-creds` (`parse-json-secrets: true`, exposed as `CREDS_*` and mapped back to the `DROPBOX_INTEGRATION_*` env vars the tests expect), plus the Codecov token.
  - `UnitTests`: the Codecov token for coverage upload.

## Fork PRs

Fork PRs cannot assume the OIDC role (GitHub withholds `id-token` from fork runs — the same limitation the old GitHub secrets had). So the `IntegrationTests` job and the coverage-upload steps are gated to same-repo runs (`push` to main, same-repo PRs, and the nightly cron). Unit tests and the linter still run on forks.

## Requires infra first

The IAM role and secrets these workflows reference must be provisioned in AWS first. **Do not merge until that infrastructure is in place and the secret values are set**, or these workflows will fail on the role-assume / secret-fetch step.

The signing key (`dropbox_api_key.snk`) is unchanged — it is checked into the repo, not a secret.
