### PR TITLE
Publish to NuGet via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/nuget_upload.yml
+++ b/.github/workflows/nuget_upload.yml
@@ -13,17 +13,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: NuGet login (Trusted Publishing via OIDC)
+        uses: NuGet/login@v1
+        id: login
         with:
-          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-dotnet-repo
-          aws-region: us-west-2
-      - name: Get NuGet token from AWS Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            NUGET_TOKEN,nuget-api-token-dropbox-sdk-dotnet
-          parse-json-secrets: false
+          user: dropbox
       - name: Pack
         run: |
           dotnet pack \
@@ -37,4 +31,4 @@ jobs:
           dotnet nuget push \
           dropbox-sdk-dotnet/Dropbox.Api/bin/Release/Dropbox.Api.$(echo "${{ github.event.release.tag_name }}" | cut -c 2-).nupkg \
           --source https://api.nuget.org/v3/index.json \
-          --api-key ${{ env.NUGET_TOKEN }}
+          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}


### PR DESCRIPTION
Switches the NuGet publish workflow from a static, AWS-fetched API key to NuGet Trusted Publishing via `NuGet/login@v1` (OIDC).

The stored API key had expired, causing the v7.1.0 and v7.2.0 release publishes to fail with 403. Trusted publishing mints a short-lived key at runtime, so there is no key to expire or rotate.

A matching Trusted Publishing policy is configured on nuget.org (owner `dropbox`, repo `dropbox/dropbox-sdk-dotnet`, workflow `nuget_upload.yml`).

Note: publishing still requires the `release` event (the version is derived from the release tag), so use a release to trigger it, not workflow_dispatch.