### PR TITLE
Revert to API-key NuGet publish

### DIFF
--- a/.github/workflows/nuget_upload.yml
+++ b/.github/workflows/nuget_upload.yml
@@ -13,11 +13,17 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - name: NuGet login (Trusted Publishing via OIDC)
-        uses: NuGet/login@v1
-        id: login
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          user: dropbox
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-dotnet-repo
+          aws-region: us-west-2
+      - name: Get NuGet token from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            NUGET_TOKEN,nuget-api-token-dropbox-sdk-dotnet
+          parse-json-secrets: false
       - name: Pack
         run: |
           dotnet pack \
@@ -31,4 +37,4 @@ jobs:
           dotnet nuget push \
           dropbox-sdk-dotnet/Dropbox.Api/bin/Release/Dropbox.Api.$(echo "${{ github.event.release.tag_name }}" | cut -c 2-).nupkg \
           --source https://api.nuget.org/v3/index.json \
-          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
+          --api-key ${{ env.NUGET_TOKEN }}


### PR DESCRIPTION
Reverts #390. `NuGet/login@v1` (Trusted Publishing) is blocked by the org's GitHub Actions allowlist, so the OIDC publish fails at startup with "the action nuget/login@v1 is not allowed".

Restores the allowlisted `aws-actions/*` flow that fetches the NuGet API key from AWS Secrets Manager.

Follow-up required: the stored `nuget-api-token-dropbox-sdk-dotnet` secret is expired (caused the v7.1.0/v7.2.0 403s). It must be rotated with a valid NuGet API key before publishing will succeed.