### PR TITLE
Bump workflow actions to Node 24 and improve Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,22 @@
 
 version: 2
 updates:
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "nuget"
+    directories:
+      - "/dropbox-sdk-dotnet/**"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    groups:
+      nuget:
+        patterns:
+          - "*"
 
+  # Group all GitHub Actions updates into one PR
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
         with:
@@ -32,13 +32,13 @@ jobs:
       # same-repo runs; unit tests themselves still run everywhere.
       - name: Configure AWS credentials (OIDC)
         if: matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-dotnet-repo
           aws-region: us-west-2
       - name: Get Codecov token from AWS Secrets Manager
         if: matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             CODECOV_TOKEN,codecov-token-dropbox-sdk-dotnet
@@ -69,13 +69,13 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.x'
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-dotnet-repo
           aws-region: us-west-2
@@ -84,7 +84,7 @@ jobs:
       # (e.g. CREDS_LEGACY_APP_KEY). The Codecov token is a plain-string secret
       # in the same fetch.
       - name: Get integration credentials from AWS Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             CREDS,dotnet-integration-test-creds
@@ -122,7 +122,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/nuget_upload.yml
+++ b/.github/workflows/nuget_upload.yml
@@ -12,14 +12,14 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-dotnet-repo
           aws-region: us-west-2
       - name: Get NuGet token from AWS Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             NUGET_TOKEN,nuget-api-token-dropbox-sdk-dotnet

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -11,14 +11,14 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-dotnet-repo
           aws-region: us-west-2
       - name: Get spec-update token from AWS Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             SPEC_UPDATE_TOKEN,spec-update-token-dropbox-sdk-dotnet


### PR DESCRIPTION
## Workflow action bumps (clears Node 20 deprecation warning)
- actions/checkout v4 -> v5
- aws-actions/configure-aws-credentials v4 -> v6
- aws-actions/aws-secretsmanager-get-secrets v2 -> v3

All are on the org Actions allowlist.

## Dependabot config
- Point nuget at the actual project tree (`/dropbox-sdk-dotnet/**`) instead of `/`, which missed the nested SDK/test/example projects.
- Run weekly instead of monthly.
- Group nuget and github-actions updates into one PR each to cut noise (mirrors dropbox/dropbox-sdk-js#1151).