### PR TITLE
Derive integration test access token from refresh token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,33 +79,29 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-dotnet-repo
           aws-region: us-west-2
-      # The integration credentials are stored as a single JSON secret; with
-      # parse-json-secrets each JSON key is exposed as env var CREDS_<KEY>
-      # (e.g. CREDS_LEGACY_APP_KEY). The Codecov token is a plain-string secret
-      # in the same fetch.
+      # The integration credentials are shared by the SDK repositories as a
+      # single JSON secret. With parse-json-secrets each JSON key is exposed as
+      # an env var named CREDS_<KEY> (e.g. CREDS_SCOPED_USER_CLIENT_ID).
       - name: Get integration credentials from AWS Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
-            CREDS,dotnet-integration-test-creds
-            CODECOV_TOKEN,codecov-token-dropbox-sdk-dotnet
+            CREDS,api-sdk-integration-test-creds
           parse-json-secrets: true
-      - name: Test Legacy User
+      - name: Get Codecov token from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        with:
+          secret-ids: |
+            CODECOV_TOKEN,codecov-token-dropbox-sdk-dotnet
+          parse-json-secrets: false
+      - name: Test Scoped User and Team
         env:
-          DROPBOX_INTEGRATION_appKey: ${{ env.CREDS_LEGACY_APP_KEY }}
-          DROPBOX_INTEGRATION_appSecret: ${{ env.CREDS_LEGACY_APP_SECRET }}
-          DROPBOX_INTEGRATION_userAccessToken: ${{ env.CREDS_LEGACY_APP_ACCESS_TOKEN }}
-          DROPBOX_INTEGRATION_userRefreshToken: ${{ env.CREDS_LEGACY_APP_REFRESH_TOKEN }}
-          DROPBOX_INTEGRATION_teamAccessToken: ${{ env.CREDS_TEAM_APP_ACCESS_TOKEN }}
-        run: |
-          dotnet test dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests --collect:"XPlat Code Coverage" -- 'DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile=**/Generated/**/*.cs'
-      - name: Test Scoped User
-        env:
-          DROPBOX_INTEGRATION_appKey: ${{ env.CREDS_SCOPED_APP_KEY }}
-          DROPBOX_INTEGRATION_appSecret: ${{ env.CREDS_SCOPED_APP_SECRET }}
-          DROPBOX_INTEGRATION_userAccessToken: ${{ env.CREDS_SCOPED_APP_ACCESS_TOKEN }}
-          DROPBOX_INTEGRATION_userRefreshToken: ${{ env.CREDS_SCOPED_APP_REFRESH_TOKEN }}
-          DROPBOX_INTEGRATION_teamAccessToken: ${{ env.CREDS_TEAM_APP_ACCESS_TOKEN }}
+          DROPBOX_INTEGRATION_appKey: ${{ env.CREDS_SCOPED_USER_CLIENT_ID }}
+          DROPBOX_INTEGRATION_appSecret: ${{ env.CREDS_SCOPED_USER_CLIENT_SECRET }}
+          DROPBOX_INTEGRATION_userRefreshToken: ${{ env.CREDS_SCOPED_USER_REFRESH_TOKEN }}
+          DROPBOX_INTEGRATION_teamAppKey: ${{ env.CREDS_SCOPED_TEAM_CLIENT_ID }}
+          DROPBOX_INTEGRATION_teamAppSecret: ${{ env.CREDS_SCOPED_TEAM_CLIENT_SECRET }}
+          DROPBOX_INTEGRATION_teamRefreshToken: ${{ env.CREDS_SCOPED_TEAM_REFRESH_TOKEN }}
         run: |
           dotnet test dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests --collect:"XPlat Code Coverage" -- 'DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile=**/Generated/**/*.cs'
       - name: Publish Coverage

--- a/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/DropboxApiTests.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/DropboxApiTests.cs
@@ -84,11 +84,13 @@ namespace Dropbox.Api.Tests
             appSecret = config["appSecret"];
 
             userRefreshToken = config["userRefreshToken"];
-            userAccessToken = config["userAccessToken"];
+            userAccessToken = GetAccessTokenFromRefreshToken(userRefreshToken, appKey, appSecret);
             client = new DropboxClient(userAccessToken);
 
-            var teamToken = config["teamAccessToken"];
-            teamClient = new DropboxTeamClient(teamToken);
+            var teamRefreshToken = config["teamRefreshToken"];
+            var teamAppKey = config["teamAppKey"];
+            var teamAppSecret = config["teamAppSecret"];
+            teamClient = new DropboxTeamClient(teamRefreshToken, teamAppKey, teamAppSecret);
 
             appClient = new DropboxAppClient(appKey, appSecret);
         }
@@ -737,6 +739,36 @@ namespace Dropbox.Api.Tests
         {
             var buffer = Encoding.UTF8.GetBytes(content);
             return new MemoryStream(buffer);
+        }
+
+        /// <summary>
+        /// Exchanges a refresh token for a short-lived access token so tests do not
+        /// need a stored access token.
+        /// </summary>
+        /// <param name="refreshToken">The OAuth2 refresh token.</param>
+        /// <param name="key">The app key.</param>
+        /// <param name="secret">The app secret.</param>
+        /// <returns>A fresh OAuth2 access token.</returns>
+        private static string GetAccessTokenFromRefreshToken(string refreshToken, string key, string secret)
+        {
+            using (var httpClient = new HttpClient())
+            {
+                var parameters = new Dictionary<string, string>
+                {
+                    { "grant_type", "refresh_token" },
+                    { "refresh_token", refreshToken },
+                    { "client_id", key },
+                    { "client_secret", secret },
+                };
+
+                var response = httpClient.PostAsync(
+                    "https://api.dropbox.com/oauth2/token",
+                    new FormUrlEncodedContent(parameters)).Result;
+                response.EnsureSuccessStatusCode();
+
+                var json = Newtonsoft.Json.Linq.JObject.Parse(response.Content.ReadAsStringAsync().Result);
+                return json["access_token"].ToString();
+            }
         }
     }
 }

--- a/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/settings.json.example
+++ b/dropbox-sdk-dotnet/Dropbox.Api.Integration.Tests/settings.json.example
@@ -1,7 +1,8 @@
 {
     "appKey": "",
     "appSecret": "",
-    "userAccessToken": "",
     "userRefreshToken": "",
-    "teamAccessToken": ""
+    "teamAppKey": "",
+    "teamAppSecret": "",
+    "teamRefreshToken": ""
 }


### PR DESCRIPTION
Mints the user access token at runtime by exchanging the refresh token, instead of reading a stored `userAccessToken`. This removes the access token from the set of secrets the integration tests require.

Access tokens are short-lived and were the recurring cause of CI auth failures ("invalid_access_token"); refresh tokens don't expire, so deriving the access token per run also removes that flakiness.