### PR TITLE
Add CodeQL scanning and harden Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: 0 0 * * *
 
+permissions:  # least privilege; jobs needing OIDC override this
+  contents: read
+
 jobs:
   UnitTests:
     strategy:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: 0 0 * * 1
+  workflow_dispatch:  # allow on-demand manual scans
+
+permissions:  # least privilege
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # required to upload CodeQL results
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: csharp
+            build-mode: none
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET 8
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.x'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,6 +8,9 @@ on:
     types: [created]
   workflow_dispatch:
 
+permissions:  # least privilege; jobs override this as needed
+  contents: read
+
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/nuget_upload.yml
+++ b/.github/workflows/nuget_upload.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [created]
 
+permissions:  # least privilege; the deploy job overrides this for OIDC
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -25,16 +28,22 @@ jobs:
             NUGET_TOKEN,nuget-api-token-dropbox-sdk-dotnet
           parse-json-secrets: false
       - name: Pack
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          version=$(echo "$RELEASE_TAG" | cut -c 2-)
           dotnet pack \
           dropbox-sdk-dotnet/Dropbox.Api \
           -p:Configuration=Release \
-          -p:Version=$(echo "${{ github.event.release.tag_name }}" | cut -c 2-) \
+          -p:Version="$version" \
           -p:AssemblyOriginatorKeyFile=dropbox_api_key.snk \
           -p:SignAssembly=true
       - name: Push
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          version=$(echo "$RELEASE_TAG" | cut -c 2-)
           dotnet nuget push \
-          dropbox-sdk-dotnet/Dropbox.Api/bin/Release/Dropbox.Api.$(echo "${{ github.event.release.tag_name }}" | cut -c 2-).nupkg \
+          "dropbox-sdk-dotnet/Dropbox.Api/bin/Release/Dropbox.Api.$version.nupkg" \
           --source https://api.nuget.org/v3/index.json \
-          --api-key ${{ env.NUGET_TOKEN }}
+          --api-key "$NUGET_TOKEN"

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [spec_update]
 
+permissions:  # least privilege; the Update job overrides this for OIDC
+  contents: read
+
 jobs:
   Update:
     runs-on: ubuntu-latest
@@ -43,25 +46,29 @@ jobs:
           git submodule update --remote --recursive
       - name: Generate Branch Name
         id: git-branch
+        env:
+          FORMATTED_TIME: ${{ steps.current-time.outputs.formattedTime }}
         run: |
-          echo "::set-output name=branch::spec_update_${{ steps.current-time.outputs.formattedTime }}"
+          echo "branch=spec_update_${FORMATTED_TIME}" >> "$GITHUB_OUTPUT"
       - name: Generate Num Diffs
         id: git-diff-num
         run: |
           diffs=$(git diff --submodule spec | grep ">" | wc -l)
           echo "Number of Spec diffs: $diffs"
-          echo "::set-output name=num-diff::$diffs"
+          echo "num-diff=$diffs" >> "$GITHUB_OUTPUT"
       - name: Generate Diff
         id: git-diff
+        env:
+          NUM_DIFF: ${{ steps.git-diff-num.outputs.num-diff }}
         run: |
           cd spec
-          gitdiff=$(git log -n ${{ steps.git-diff-num.outputs.num-diff }} --pretty="format:%n %H %n%n %b")
+          gitdiff=$(git log -n "$NUM_DIFF" --pretty="format:%n %H %n%n %b")
           commit="Automated Spec Update $gitdiff"
-          commit="${commit//'%'/'%25'}"
-          commit="${commit//$'\n'/'%0A'}"
-          commit="${commit//$'\r'/'%0D'}"
-          echo "Commit Message: $commit"
-          echo "::set-output name=commit::$commit"
+          {
+            echo "commit<<SPEC_UPDATE_EOF"
+            echo "$commit"
+            echo "SPEC_UPDATE_EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Generate New Routes
         run: |
           python generator/generate_routes.py


### PR DESCRIPTION
## Summary

- add weekly, push, pull-request, and manual CodeQL scans for C# and GitHub Actions
- set least-privilege default permissions across existing workflows while preserving job-level OIDC and deployment permissions
- move release tags and generated values through environment variables and `$GITHUB_OUTPUT` instead of direct expression interpolation and deprecated `set-output` commands
- use CodeQL Action v4 for the current Node 24 runtime

## Why

Several workflows relied on implicit token permissions, deprecated output syntax, or direct GitHub expression interpolation inside shell scripts. These changes make permissions explicit, reduce shell-injection risk, modernize workflow outputs, and add security scanning.

## Impact

CI, documentation publishing, NuGet publishing, and automated spec updates retain their existing triggers and behavior. CodeQL adds security analysis for C# sources and workflow files.

## Validation

- `actionlint .github/workflows/codeql.yml`
- `git diff --check`
- reviewed all changed workflow permissions and shell interpolation paths

Full-repository `actionlint` still reports the pre-existing unsupported `concurrency.queue` key in `ci.yml` and an unchanged shell style warning in `spec_update.yml`.
