### PR TITLE
Fix chunk upload offset overflow

### DIFF
--- a/dropbox-sdk-dotnet/Examples/SimpleTest/Program.cs
+++ b/dropbox-sdk-dotnet/Examples/SimpleTest/Program.cs
@@ -494,7 +494,7 @@ namespace SimpleTest
 
                         else
                         {
-                            UploadSessionCursor cursor = new UploadSessionCursor(sessionId, (ulong)(chunkSize * idx));
+                            UploadSessionCursor cursor = new UploadSessionCursor(sessionId, (ulong)chunkSize * (ulong)idx);
 
                             if (idx == numChunks - 1)
                             {


### PR DESCRIPTION
## Summary

- cast `chunkSize` and `idx` to `ulong` before calculating the upload-session cursor offset
- prevent the `SimpleTest` chunk-upload example from producing an invalid offset for files larger than 2 GiB

## Root cause

The previous expression multiplied two `int` values before converting the result to `ulong`. At chunk index 16,384 with the example's 128 KiB chunk size, the intermediate value overflows `Int32`, and converting the negative result to `ulong` produces a very large invalid cursor offset.

## User impact

Large chunked uploads based on the sample no longer fail with `incorrect_offset` after crossing the 2 GiB boundary.

Fixes #122.

## Validation

- `git diff --check`
- `dotnet test dropbox-sdk-dotnet/Dropbox.Api.Unit.Tests/Dropbox.Api.Unit.Tests.csproj --no-restore`

A direct build of the legacy `SimpleTest` project requires its old `packages.config` dependencies, which are not installed in the local environment.
