### PR TITLE
Normalize empty OAuth tokens

### DIFF
--- a/dropbox-sdk-dotnet/Dropbox.Api.Unit.Tests/DropboxClientTokenTests.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api.Unit.Tests/DropboxClientTokenTests.cs
@@ -1,0 +1,109 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DropboxClientTokenTests.cs" company="Dropbox Inc">
+// Copyright (c) Dropbox Inc. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+namespace Dropbox.Api.Unit.Tests
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Tests token validation and normalization for Dropbox clients.
+    /// </summary>
+    [TestClass]
+    public class DropboxClientTokenTests
+    {
+        /// <summary>
+        /// Verifies an empty access token is rejected by the user client.
+        /// </summary>
+        [TestMethod]
+        public void TestDropboxClientRejectsEmptyAccessToken()
+        {
+            Assert.ThrowsExactly<ArgumentException>(() => CreateDropboxClientWithAccessToken(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies an empty refresh token is rejected by the user client.
+        /// </summary>
+        [TestMethod]
+        public void TestDropboxClientRejectsEmptyRefreshToken()
+        {
+            Assert.ThrowsExactly<ArgumentException>(() => CreateDropboxClientWithRefreshToken(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies an empty access token is rejected by the team client.
+        /// </summary>
+        [TestMethod]
+        public void TestDropboxTeamClientRejectsEmptyAccessToken()
+        {
+            Assert.ThrowsExactly<ArgumentException>(() => CreateDropboxTeamClientWithAccessToken(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies an empty refresh token is rejected by the team client.
+        /// </summary>
+        [TestMethod]
+        public void TestDropboxTeamClientRejectsEmptyRefreshToken()
+        {
+            Assert.ThrowsExactly<ArgumentException>(() => CreateDropboxTeamClientWithRefreshToken(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies empty token strings are normalized to missing tokens.
+        /// </summary>
+        [TestMethod]
+        public void TestRequestHandlerOptionsNormalizeEmptyTokens()
+        {
+            var emptyAccessTokenOptions = new DropboxRequestHandlerOptions(
+                new DropboxClientConfig(),
+                string.Empty,
+                "refresh-token",
+                null,
+                "app-key",
+                null);
+            var emptyRefreshTokenOptions = new DropboxRequestHandlerOptions(
+                new DropboxClientConfig(),
+                "access-token",
+                string.Empty,
+                null,
+                "app-key",
+                null);
+
+            Assert.IsNull(emptyAccessTokenOptions.OAuth2AccessToken);
+            Assert.AreEqual("refresh-token", emptyAccessTokenOptions.OAuth2RefreshToken);
+            Assert.AreEqual("access-token", emptyRefreshTokenOptions.OAuth2AccessToken);
+            Assert.IsNull(emptyRefreshTokenOptions.OAuth2RefreshToken);
+        }
+
+        private static void CreateDropboxClientWithAccessToken(string token)
+        {
+            using (var client = new DropboxClient(token))
+            {
+            }
+        }
+
+        private static void CreateDropboxClientWithRefreshToken(string token)
+        {
+            using (var client = new DropboxClient(token, "app-key"))
+            {
+            }
+        }
+
+        private static void CreateDropboxTeamClientWithAccessToken(string token)
+        {
+            using (var client = new DropboxTeamClient(token))
+            {
+            }
+        }
+
+        private static void CreateDropboxTeamClientWithRefreshToken(string token)
+        {
+            using (var client = new DropboxTeamClient(token, "app-key"))
+            {
+            }
+        }
+    }
+}

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxClient.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxClient.cs
@@ -128,9 +128,9 @@ namespace Dropbox.Api
         public DropboxClient(string oauth2AccessToken, string oauth2RefreshToken, DateTime oauth2AccessTokenExpiresAt, string appKey, DropboxClientConfig config)
             : this(new DropboxRequestHandlerOptions(config, oauth2AccessToken, oauth2RefreshToken, oauth2AccessTokenExpiresAt, appKey, null))
         {
-            if (oauth2AccessToken == null && oauth2RefreshToken == null)
+            if (string.IsNullOrEmpty(oauth2AccessToken) && string.IsNullOrEmpty(oauth2RefreshToken))
             {
-                throw new ArgumentException("Cannot pass in both null access and refresh token");
+                throw new ArgumentException("Access token and refresh token cannot both be null or empty.");
             }
         }
 
@@ -158,9 +158,9 @@ namespace Dropbox.Api
         public DropboxClient(string oauth2AccessToken, string oauth2RefreshToken, DateTime oauth2AccessTokenExpiresAt, string appKey, string appSecret, DropboxClientConfig config)
             : this(new DropboxRequestHandlerOptions(config, oauth2AccessToken, oauth2RefreshToken, oauth2AccessTokenExpiresAt, appKey, appSecret))
         {
-            if (oauth2AccessToken == null && oauth2RefreshToken == null)
+            if (string.IsNullOrEmpty(oauth2AccessToken) && string.IsNullOrEmpty(oauth2RefreshToken))
             {
-                throw new ArgumentException("Cannot pass in both null access and refresh token");
+                throw new ArgumentException("Access token and refresh token cannot both be null or empty.");
             }
         }
 
@@ -175,9 +175,9 @@ namespace Dropbox.Api
         public DropboxClient(string oauth2AccessToken, string oauth2RefreshToken, string appKey, string appSecret, DropboxClientConfig config)
             : this(new DropboxRequestHandlerOptions(config, oauth2AccessToken, oauth2RefreshToken, null, appKey, appSecret))
         {
-            if (oauth2AccessToken == null && oauth2RefreshToken == null)
+            if (string.IsNullOrEmpty(oauth2AccessToken) && string.IsNullOrEmpty(oauth2RefreshToken))
             {
-                throw new ArgumentException("Cannot pass in both null access and refresh token");
+                throw new ArgumentException("Access token and refresh token cannot both be null or empty.");
             }
         }
 

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxRequestHandler.cs
@@ -1164,8 +1164,8 @@ namespace Dropbox.Api
             this.LongPollHttpClient = longPollHttpClient;
             this.DisposeUploadStream = disposeUploadStream;
             this.AutoContentHash = autoContentHash;
-            this.OAuth2AccessToken = oauth2AccessToken;
-            this.OAuth2RefreshToken = oauth2RefreshToken;
+            this.OAuth2AccessToken = string.IsNullOrEmpty(oauth2AccessToken) ? null : oauth2AccessToken;
+            this.OAuth2RefreshToken = string.IsNullOrEmpty(oauth2RefreshToken) ? null : oauth2RefreshToken;
             this.OAuth2AccessTokenExpiresAt = oauth2AccessTokenExpiresAt;
             this.AppKey = appKey;
             this.AppSecret = appSecret;

--- a/dropbox-sdk-dotnet/Dropbox.Api/DropboxTeamClient.cs
+++ b/dropbox-sdk-dotnet/Dropbox.Api/DropboxTeamClient.cs
@@ -132,9 +132,9 @@ namespace Dropbox.Api
         public DropboxTeamClient(string oauth2AccessToken, string oauth2RefreshToken, DateTime oauth2AccessTokenExpiresAt, string appKey, DropboxClientConfig config)
             : this(new DropboxRequestHandlerOptions(config, oauth2AccessToken, oauth2RefreshToken, oauth2AccessTokenExpiresAt, appKey, null))
         {
-            if (oauth2AccessToken == null && oauth2RefreshToken == null)
+            if (string.IsNullOrEmpty(oauth2AccessToken) && string.IsNullOrEmpty(oauth2RefreshToken))
             {
-                throw new ArgumentException("Cannot pass in both null access and refresh token");
+                throw new ArgumentException("Access token and refresh token cannot both be null or empty.");
             }
         }
 
@@ -162,9 +162,9 @@ namespace Dropbox.Api
         public DropboxTeamClient(string oauth2AccessToken, string oauth2RefreshToken, DateTime oauth2AccessTokenExpiresAt, string appKey, string appSecret, DropboxClientConfig config)
             : this(new DropboxRequestHandlerOptions(config, oauth2AccessToken, oauth2RefreshToken, oauth2AccessTokenExpiresAt, appKey, appSecret))
         {
-            if (oauth2AccessToken == null && oauth2RefreshToken == null)
+            if (string.IsNullOrEmpty(oauth2AccessToken) && string.IsNullOrEmpty(oauth2RefreshToken))
             {
-                throw new ArgumentException("Cannot pass in both null access and refresh token");
+                throw new ArgumentException("Access token and refresh token cannot both be null or empty.");
             }
         }
 
@@ -179,9 +179,9 @@ namespace Dropbox.Api
         public DropboxTeamClient(string oauth2AccessToken, string oauth2RefreshToken, string appKey, string appSecret, DropboxClientConfig config)
             : this(new DropboxRequestHandlerOptions(config, oauth2AccessToken, oauth2RefreshToken, null, appKey, appSecret))
         {
-            if (oauth2AccessToken == null && oauth2RefreshToken == null)
+            if (string.IsNullOrEmpty(oauth2AccessToken) && string.IsNullOrEmpty(oauth2RefreshToken))
             {
-                throw new ArgumentException("Cannot pass in both null access and refresh token");
+                throw new ArgumentException("Access token and refresh token cannot both be null or empty.");
             }
         }
 


### PR DESCRIPTION
## Summary

- normalize empty OAuth access and refresh tokens to `null`
- reject user and team client configurations when both tokens are null or empty
- add focused coverage for access and refresh token handling in `DropboxClient` and `DropboxTeamClient`

## Root cause

The client constructors only checked whether both token arguments were `null`. Empty strings therefore passed validation and were stored as if they were usable credentials, causing authentication or refresh behavior to fail later instead of reporting the invalid configuration at construction time.

## User impact

Applications can pass optional token values without separately translating empty strings to `null`. A valid token is preserved when the other token is empty, while configurations with no usable token fail immediately with a clear `ArgumentException`.

Fixes #309.

## Validation

### Reproduction before the fix

The five new targeted tests all failed: four constructors accepted empty tokens and handler options retained an empty access token.

### After the fix

- targeted token tests: 5 passed
- full unit suite: 20 passed
- `dotnet format` verification completed without formatting changes
- `git diff --check`
